### PR TITLE
Add support for linting build.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ And make the resulting file pretty:
 npx prettier --write ./src/config.schema.json
 ```
 
+The same, of course, applies to the `src/build.schema.ts` file.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/src/build.schema.json
+++ b/src/build.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "properties": {
+    "args": {
+      "additionalProperties": {},
+      "default": {},
+      "type": "object"
+    },
+    "build_from": {
+      "additionalProperties": false,
+      "default": {},
+      "properties": {
+        "aarch64": {
+          "default": "homeassistant/aarch64-base:latest",
+          "pattern": "^([a-zA-Z\\-\\.:\\d{}]+/)*?([\\-\\w{}]+)/([\\-\\w{}]+)(:[\\.\\-\\w{}]+)?$",
+          "type": "string"
+        },
+        "amd64": {
+          "default": "homeassistant/amd64-base:latest",
+          "pattern": "^([a-zA-Z\\-\\.:\\d{}]+/)*?([\\-\\w{}]+)/([\\-\\w{}]+)(:[\\.\\-\\w{}]+)?$",
+          "type": "string"
+        },
+        "armhf": {
+          "default": "homeassistant/armhf-base:latest",
+          "pattern": "^([a-zA-Z\\-\\.:\\d{}]+/)*?([\\-\\w{}]+)/([\\-\\w{}]+)(:[\\.\\-\\w{}]+)?$",
+          "type": "string"
+        },
+        "armv7": {
+          "default": "homeassistant/armv7-base:latest",
+          "pattern": "^([a-zA-Z\\-\\.:\\d{}]+/)*?([\\-\\w{}]+)/([\\-\\w{}]+)(:[\\.\\-\\w{}]+)?$",
+          "type": "string"
+        },
+        "i386": {
+          "default": "homeassistant/i386-base:latest",
+          "pattern": "^([a-zA-Z\\-\\.:\\d{}]+/)*?([\\-\\w{}]+)/([\\-\\w{}]+)(:[\\.\\-\\w{}]+)?$",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "squash": {
+      "default": false,
+      "type": "boolean"
+    }
+  },
+  "type": "object"
+}

--- a/src/build.schema.ts
+++ b/src/build.schema.ts
@@ -1,0 +1,46 @@
+export interface Build {
+  /**
+   * @default {}
+   */
+  args?: { [key: string]: any; };
+
+  /**
+   * @default {}
+   */
+  build_from?: {
+      /**
+       * @TJS-pattern ^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$
+       * @default homeassistant/aarch64-base:latest
+       */
+      aarch64?: string;
+
+      /**
+       * @TJS-pattern ^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$
+       * @default homeassistant/amd64-base:latest
+       */
+      amd64?: string;
+
+      /**
+       * @TJS-pattern ^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$
+       * @default homeassistant/armhf-base:latest
+       */
+      armhf?: string;
+
+      /**
+       * @TJS-pattern ^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$
+       * @default homeassistant/armv7-base:latest
+       */
+      armv7?: string;
+
+      /**
+       * @TJS-pattern ^([a-zA-Z\-\.:\d{}]+/)*?([\-\w{}]+)/([\-\w{}]+)(:[\.\-\w{}]+)?$
+       * @default homeassistant/i386-base:latest
+       */
+      i386?: string;
+  };
+
+  /**
+   * @default false
+   */
+  squash?: boolean;
+}


### PR DESCRIPTION
This PR adds support for linting the `build.json` file if it exists. It also adds the schema that belongs to it.

Additionally, some checks for the community add-ons are added, e.g., to ensure the architectures in the build.json match the architectures listed in the config.json file.

