### PR TITLE
Add new optional/default from Supervisor 2021.01.0 release

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -30,6 +30,7 @@
       "type": "boolean"
     },
     "boot": {
+      "default": "auto",
       "enum": ["auto", "manual"],
       "type": "string"
     },
@@ -144,6 +145,7 @@
     },
     "options": {
       "additionalProperties": {},
+      "default": {},
       "type": "object"
     },
     "panel_admin": {
@@ -185,6 +187,7 @@
     },
     "schema": {
       "additionalProperties": {},
+      "default": {},
       "type": "object"
     },
     "services": {
@@ -208,6 +211,7 @@
       "type": "string"
     },
     "startup": {
+      "default": "application",
       "enum": ["application", "initialize", "once", "services", "system"],
       "type": "string"
     },
@@ -248,16 +252,6 @@
       "type": "string"
     }
   },
-  "required": [
-    "arch",
-    "boot",
-    "description",
-    "name",
-    "options",
-    "schema",
-    "slug",
-    "startup",
-    "version"
-  ],
+  "required": ["arch", "description", "name", "slug", "version"],
   "type": "object"
 }

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -29,7 +29,10 @@ export interface Config {
    */
   auto_uart?: boolean;
 
-  boot: "auto" | "manual";
+  /**
+   * @default auto
+   */
+  boot?: "auto" | "manual";
 
   description: string;
 
@@ -148,7 +151,10 @@ export interface Config {
 
   name: string;
 
-  options: { [key: string]: any; };
+  /**
+   * @default {}
+   */
+  options?: { [key: string]: any; };
 
   /**
    * @default true
@@ -181,7 +187,10 @@ export interface Config {
 
   privileged?: "DAC_READ_SEARCH" | "NET_ADMIN" | "SYS_ADMIN" | "SYS_MODULE" | "SYS_NICE" | "SYS_PTRACE" | "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME";
 
-  schema: { [key: string]: any; };
+  /**
+   * @default {}
+   */
+  schema?: { [key: string]: any; };
 
   /**
    * @items.pattern ^(?P<service>mqtt|mysql):(?P<rights>provide|want|need)$
@@ -197,7 +206,10 @@ export interface Config {
    */
   stage?: "stable" | "experimental" | "deprecated";
 
-  startup: "application" | "initialize" | "once" | "services" | "system";
+  /**
+   * @default application
+   */
+  startup?: "application" | "initialize" | "once" | "services" | "system";
 
   /**
    * @default false


### PR DESCRIPTION
Adds new schema changes from Supervisor 2021.01.0.

- `boot` is now optional, and has a default value of `auto`.
- `options` is now optional
- `schema` is now optional
- `startup` is now optional, and has a default value of `application`
