### PR TITLE
Fix add-on config map check regular expression

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -136,7 +136,7 @@
     },
     "map": {
       "items": {
-        "pattern": "^(config|ssl|addons|backup|share|media)(rw|ro)?$"
+        "pattern": "^(config|ssl|addons|backup|share|media)(:(rw|ro))?$"
       },
       "type": "array"
     },

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -145,7 +145,7 @@ export interface Config {
   machine?: string[];
 
   /**
-   * @items.pattern ^(config|ssl|addons|backup|share|media)(rw|ro)?$
+   * @items.pattern ^(config|ssl|addons|backup|share|media)(:(rw|ro))?$
    */
   map?: string[];
 


### PR DESCRIPTION
Fixes an issue where the map wasn't validated correctly.

This wasn't considered valid for the mapping configuration:

```json
{
  "map": ["ssl:rw"]
}
```