### PR TITLE
Fix port description type

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -161,7 +161,7 @@
     },
     "ports": {
       "additionalProperties": {
-        "type": "integer"
+        "type": "string"
       },
       "type": "object"
     },

--- a/src/config.schema.ts
+++ b/src/config.schema.ts
@@ -177,13 +177,7 @@ export interface Config {
     [key: string]: number;
   };
 
-  ports?: {
-    /**
-     * @min 1
-     * @max 65535
-     */
-    [key: string]: number;
-  };
+  ports?: { [key: string]: string; };
 
   privileged?: "DAC_READ_SEARCH" | "NET_ADMIN" | "SYS_ADMIN" | "SYS_MODULE" | "SYS_NICE" | "SYS_PTRACE" | "SYS_RAWIO" | "SYS_RESOURCE" | "SYS_TIME";
 


### PR DESCRIPTION
Fixes an issue with the port descriptions in the add-on configuration; expecting an integer. Of course, the description should have been a string.