### PR TITLE
Fix exit code reset

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -66,7 +66,6 @@ if build.exists():
         build_schema = json.load(fp)
 
     v = DefaultValidatingDraft7Validator(build_schema)
-    exit_code = 0
 
     for error in sorted(v.iter_errors(build_configuration), key=str):
         print(f"::error file={build}::{error.message}")


### PR DESCRIPTION
Fixes an issue where the exit code was reset when a build.json is processed.

This causes the action to succeed successfully in case the config.json has errors, but build.json does not.

It now exists properly again.