### PR TITLE
Fix port number schema's

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -114,7 +114,9 @@
     },
     "ingress_port": {
       "default": 8099,
-      "type": "integer"
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 65535
     },
     "init": {
       "default": true,
@@ -161,7 +163,10 @@
     },
     "ports": {
       "additionalProperties": {
-        "type": "integer"
+        "anyOf": [
+          { "type": "integer", "minimum": 1, "maximum": 65535 },
+          { "type": "null" }
+        ]
       },
       "type": "object"
     },


### PR DESCRIPTION
The port number did not generate well from the original schema generator.

This corrects the JSON schema to handle the port numbers correctly.