### PR TITLE
Fix 'homeassistant' property to be of type string

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -80,7 +80,7 @@
     },
     "homeassistant": {
       "default": false,
-      "type": "boolean"
+      "type": "string"
     },
     "homeassistant_api": {
       "default": false,


### PR DESCRIPTION
Fixes an issue in the configuration schema, where the Home Assistant minimal version expected a boolean. This of course should be a string.

```json
{
  "homeassistant": "2021.1"
}
```