### PR TITLE
Check if 'webui' is abset when Ingress is enabled

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -57,6 +57,10 @@ for error in sorted(v.iter_errors(configuration), key=str):
     print(f"::error file={config}::{error.message}")
     exit_code = 1
 
+if configuration.get("ingress", False) and configuration.get("webui"):
+    print(f"::error file={config}::'webui' should be removed, Ingress is enabled.")
+    exit_code = 1
+
 build = path / "build.json"
 if build.exists():
     with open(build) as fp:


### PR DESCRIPTION
In case Ingress is enabled with an add-on, the WEBUI button will always open via Ingress.
This makes setting `webui` in the add-on configuration at that point, unneeded.

This PR adds an additional check for this.