### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out code from GitHub
-        uses: actions/checkout@@v2.3.4
+        uses: actions/checkout@v2.3.4
       - name: 🚀 Run yamllint
         uses: frenck/action-yamllint@v1.0.2
 


### PR DESCRIPTION
The GitHub Actions linter workflow broke in this repository, due to a typo. Didn't cause any problems before, apparently, GitHub improved 🤷 