### PR TITLE
Adjust schema to match Supervisor 2021.2 new features

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -39,7 +39,7 @@
     },
     "devices": {
       "items": {
-        "pattern": "^(.*):(.*):([rwm]{1,3})$"
+        "type": "string"
       },
       "type": "array"
     },
@@ -232,7 +232,12 @@
       "type": "integer"
     },
     "tmpfs": {
-      "type": "string"
+      "default": false,
+      "type": ["string", "boolean"]
+    },
+    "uart": {
+      "default": false,
+      "type": "boolean"
     },
     "udev": {
       "default": false,

--- a/src/lint.py
+++ b/src/lint.py
@@ -93,6 +93,22 @@ if set(configuration.get("ports", {})) != set(
     print(f"::error file={config}::'ports' and 'ports_description' do not match.")
     exit_code = 1
 
+if "auto_uart" in configuration:
+    print(f"::error file={config}::'auto_uart' is deprecated, use 'uart' instead.")
+    exit_code = 1
+
+if any(":" in line for line in configuration.get("devices", [])):
+    print(
+        f"::error file={config}::'devices' uses a deprecated format, the new format uses a list of paths only."
+    )
+    exit_code = 1
+
+if not isinstance(configuration.get("tmpfs", False), bool):
+    print(
+        f"::error file={config}::'tmpfs' use a deprecated format, it is a boolean now."
+    )
+    exit_code = 1
+
 # Checks regarding build.json (if found)
 build = path / "build.json"
 if build.exists():


### PR DESCRIPTION
Adds support for the latest schema changes in the Supervisor.

- `auto_uart` is deprecated.
- `uart` is a new option.
- `tmpfs` is now a boolean.
- `devices` now expects a list of paths.
