### PR TITLE
Add checks and warnings for use of full_access

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -93,6 +93,19 @@ if set(configuration.get("ports", {})) != set(
     print(f"::error file={config}::'ports' and 'ports_description' do not match.")
     exit_code = 1
 
+if configuration.get("full_access") and any(
+    item in ["devices", "gpio", "uart", "usb"] for item in configuration
+):
+    print(
+        f"::error file={config}::'full_access', don't add 'devices', 'uart', 'usb' or 'gpio' this is not needed".
+    )
+    exit_code = 1
+
+if configuration.get("full_access"):
+    print(
+        f"::warning file={config}::'full_access' consider using other options instead, like 'devices'".
+    )
+
 if "auto_uart" in configuration:
     print(f"::error file={config}::'auto_uart' is deprecated, use 'uart' instead.")
     exit_code = 1


### PR DESCRIPTION
Adds additional checks when using the `full_access` add-on option.

- Warn if used at all.
- Error if used together with `devices`, `gpio`, `usb` or `uart`.

See: https://github.com/home-assistant/developers.home-assistant/pull/812