### PR TITLE
Error if ingress options are defined but ingress is not enabled

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -82,6 +82,11 @@ if configuration.get("ingress", False):
             "In Ingress port doesn't have to be randomized (not 0)."
         )
         exit_code = 1
+else:
+    for option in ("ingress_port", "ingress_entry", "ingress_stream",):
+        if configuration.get(option) is not None:
+            print(f"::error file={config}::'{option}' is defined, but `ingress` is not enabled")
+            exit_code = 1
 
 if "ports" in configuration and "ports_description" not in configuration:
     print(f"::error file={config}::'ports' is defined without 'ports_description'.")


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/remarkjs/.github/blob/main/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/remarkjs/.github/blob/main/support.md
https://github.com/remarkjs/.github/blob/main/contributing.md
-->

When `ingress` is `False`, "ingress_port", "ingress_entry" and "ingress_stream" should not be in the config
