### PR TITLE
Add support for new snapshot options

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -220,6 +220,17 @@
     "slug": {
       "type": "string"
     },
+    "snapshot": {
+      "default": "hot",
+      "enum": ["hot", "cold"],
+      "type": "string"
+    },
+    "snapshot_pre": {
+      "type": "string"
+    },
+    "snapshot_post": {
+      "type": "string"
+    },
     "snapshot_exclude": {
       "items": {
         "type": "string"

--- a/src/lint.py
+++ b/src/lint.py
@@ -131,6 +131,14 @@ if not isinstance(configuration.get("tmpfs", False), bool):
     )
     exit_code = 1
 
+if configuration.get("snapshot", "hot") == "cold":
+    for option in ["snapshot_pre", "snapshot_post"]:
+        if option in configuration:
+            print(
+                f"::error file={config}::'{option}' is not valid when using cold snapshots."
+            )
+            exit_code = 1
+
 # Checks regarding build file(if found)
 for file_type in ("json", "yaml", "yml"):
     build = path / f"build.{file_type}"


### PR DESCRIPTION
This PR adds support for some newer options that were still missing in the validator:

- `snapshot`
- `snapshot_pre`
- `snapshot_post`

Additionally, it will check that pre/post is not used when a cold snapshot is configured.