### PR TITLE
Prepare snapshot -> backup migration

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -29,6 +29,23 @@
       "default": false,
       "type": "boolean"
     },
+    "backup": {
+      "default": "hot",
+      "enum": ["hot", "cold"],
+      "type": "string"
+    },
+    "backup_exclude": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "backup_pre": {
+      "type": "string"
+    },
+    "backup_post": {
+      "type": "string"
+    },
     "boot": {
       "default": "auto",
       "enum": ["auto", "manual"],
@@ -225,17 +242,17 @@
       "enum": ["hot", "cold"],
       "type": "string"
     },
-    "snapshot_pre": {
-      "type": "string"
-    },
-    "snapshot_post": {
-      "type": "string"
-    },
     "snapshot_exclude": {
       "items": {
         "type": "string"
       },
       "type": "array"
+    },
+    "snapshot_pre": {
+      "type": "string"
+    },
+    "snapshot_post": {
+      "type": "string"
     },
     "stage": {
       "default": "stable",

--- a/src/lint.py
+++ b/src/lint.py
@@ -139,6 +139,14 @@ if configuration.get("snapshot", "hot") == "cold":
             )
             exit_code = 1
 
+if configuration.get("backup", "hot") == "cold":
+    for option in ["backup_pre", "backup_post"]:
+        if option in configuration:
+            print(
+                f"::error file={config}::'{option}' is not valid when using cold backups."
+            )
+            exit_code = 1
+
 # Checks regarding build file(if found)
 for file_type in ("json", "yaml", "yml"):
     build = path / f"build.{file_type}"


### PR DESCRIPTION
This PR prepares for the snapshot -> backup migration by already allowing the new backup version to be used.

See: <https://github.com/home-assistant/supervisor/pull/2940>

Once the change has been pushed upstream, we need to add extra checks/warnings.

