### PR TITLE
Deprecate snapshot options, use backup instead

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -147,6 +147,22 @@ if configuration.get("backup", "hot") == "cold":
             )
             exit_code = 1
 
+if "snapshot" in configuration:
+    print(f"::error file={config}::'snapshot' is deprecated, use 'backup' instead.")
+    exit_code = 1
+
+if "snapshot_exclude" in configuration:
+    print(f"::error file={config}::'snapshot_exclude' is deprecated, use 'backup_exclude' instead.")
+    exit_code = 1
+
+if "snapshot_pre" in configuration:
+    print(f"::error file={config}::'snapshot_pre' is deprecated, use 'backup_pre' instead.")
+    exit_code = 1
+
+if "snapshot_post" in configuration:
+    print(f"::error file={config}::'snapshot_post' is deprecated, use 'backup_post' instead.")
+    exit_code = 1
+
 # Checks regarding build file(if found)
 for file_type in ("json", "yaml", "yml"):
     build = path / f"build.{file_type}"


### PR DESCRIPTION
This PR adds configuration validation errors for the snapshot -> backup change/migration.

The following options have been renamed:

- `snapshot` -> `backup`
- `snapshot_exclude` -> `backup_exclude`
- `snapshot_pre` -> `backup_pre`
- `snapshot_post` -> `backup_post`

🕐 Awaits release of: <https://github.com/home-assistant/supervisor/pull/2940>