### PR TITLE
Add codenotary support to add-on configuration

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -51,6 +51,10 @@
       "enum": ["auto", "manual"],
       "type": "string"
     },
+    "codenotary": {
+      "type": "string",
+      "format": "email"
+    },
     "description": {
       "type": "string"
     },


### PR DESCRIPTION
Add support for setting the codenotary signers emails address in the add-on configuration


https://github.com/home-assistant/supervisor/pull/3450