### PR TITLE
Allow build.json without build_from

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -173,7 +173,7 @@ if not build.exists():
     print(f"::error file={build}::The build.json file is missing")
     sys.exit(1)
 
-if set(configuration["arch"]) != set(build_configuration["build_from"]):
+if "build_from" in build_configuration and set(configuration["arch"]) != set(build_configuration["build_from"]):
     print(f"::error file={build}::Architectures in config and build do not match")
     exit_code = 1
 


### PR DESCRIPTION
This change is for preparing for single image multi arch deployments for add-ons.

The linter currently checks if `build_from` in the build.yaml file matches the archs listed in config.yaml.

This PR adds a little slack to that, to skip this check if `build_from` is missing in build.yaml completely.