### PR TITLE
Only require build_from and arch to match when not using image manifest

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -173,7 +173,7 @@ if not build.exists():
     print(f"::error file={build}::The build.json file is missing")
     sys.exit(1)
 
-if "build_from" in build_configuration and set(configuration["arch"]) != set(build_configuration["build_from"]):
+if "build_from" in build_configuration and not isinstance(build_configuration["build_from"], str) and set(configuration["arch"]) != set(build_configuration["build_from"]):
     print(f"::error file={build}::Architectures in config and build do not match")
     exit_code = 1
 


### PR DESCRIPTION
When in community add-ons mode, we require the arch & build_from to match in architectures. When using a multiarch manifest image in the build configuration, that rule shouldn't apply.