### PR TITLE
Remove incorrect ingress port on host network rule

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -73,16 +73,6 @@ if configuration.get("ingress", False):
         exit_code = 1
 
     if (
-        configuration.get("host_network", False)
-        and configuration.get("ingress_port", 8099) != 0
-    ):
-        print(
-            f"::error file={config}::'ingress_port' this add-on runs on the host network. "
-            "Ingress port should be set to 0."
-        )
-        exit_code = 1
-
-    if (
         not configuration.get("host_network", False)
         and configuration.get("ingress_port", 8099) == 0
     ):


### PR DESCRIPTION
This PR removes a linting check/rule that ensured if `ingress_port` was set to `0` when the addon ran on the host network.

That rule is actually incorrect. In case an application supports ingress directly, no proxy is needed, and thus the application port can be used directly.