### PR TITLE
:fire: Remove checks for port descriptions

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -82,16 +82,6 @@ if configuration.get("ingress", False):
         )
         exit_code = 1
 
-if "ports" in configuration and "ports_description" not in configuration:
-    print(f"::error file={config}::'ports' is defined without 'ports_description'.")
-    exit_code = 1
-
-if set(configuration.get("ports", {})) != set(
-    configuration.get("ports_description", {})
-):
-    print(f"::error file={config}::'ports' and 'ports_description' do not match.")
-    exit_code = 1
-
 if configuration.get("full_access") and any(
     item in ["devices", "gpio", "uart", "usb"] for item in configuration
 ):


### PR DESCRIPTION
The `port_description` is no longer required in the add-on configuration.

Those can be defined in the translation files alternatively (and probably recommended). Therefore, this PR removes the checks that ensured `port_description` where needed.

