### PR TITLE
Detect use of obsolete watchdog configuration option

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -119,6 +119,12 @@ if configuration.get("backup", "hot") == "cold":
             )
             exit_code = 1
 
+if configuration.get("watchdog"):
+    print(
+        f"::error file={config}::'watchdog', is obsolete. Use the native Docker HEALTHCHECK directive instead."
+    )
+    exit_code = 1
+
 # Checks regarding build file(if found)
 for file_type in ("json", "yaml", "yml"):
     build = path / f"build.{file_type}"


### PR DESCRIPTION
Detect and error on the use of the `watchdog` configuration option. It became fully obsolete now the Supervisor supports the native Docker HEALTHCHECK directive natively.

There are so many advantages to using the HEALTHCHECK (in terms of features, being event driven and much more), that is makes absolutely no sense to use the older `watchdog` feature.
