### PR TITLE
Add checks for conflicting mapping options

### DIFF
--- a/src/lint.py
+++ b/src/lint.py
@@ -133,6 +133,41 @@ if configuration.get("map") and (
         f"::warning file={config}::'map' contains the 'config' folder, which has been replaced by 'homeassistant_config'. See: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config"
     )
 
+if (
+    configuration.get("map")
+    and (
+        "config" in configuration["map"]
+        or "config:rw" in configuration["map"]
+        or "config:ro" in configuration["map"]
+    )
+    and (
+        "homeassistant_config" in configuration["map"]
+        or "homeassistant_config:rw" in configuration["map"]
+        or "homeassistant_config:ro" in configuration["map"]
+    )
+):
+    print(
+        f"::error file={config}::'map' contains both the 'config' and 'homeassistant_config' folder, which are conflicting. See: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config"
+    )
+    exit_code = 1
+
+if (
+    configuration.get("map")
+    and (
+        "config" in configuration["map"]
+        or "config:rw" in configuration["map"]
+        or "config:ro" in configuration["map"]
+    )
+    and (
+        "addon_config" in configuration["map"]
+        or "addon_config:rw" in configuration["map"]
+        or "addon_config:ro" in configuration["map"]
+    )
+):
+    print(
+        f"::error file={config}::'map' contains both the 'config' and 'addon_config' folder, which are conflicting. See: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config"
+    )
+    exit_code = 1
 
 # Checks regarding build file(if found)
 for file_type in ("json", "yaml", "yml"):


### PR DESCRIPTION
This PR adds additional linter checks to offending settings in the mapping options.

`homeassistant_config` and `config` conflict. They both have the same goal, but one is the latter is the older deprecated version.

`addon_config` conflicts with `config`, as those share the same mount destination (`/config`).
