### PR TITLE
Adds breaking_versions config option check

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -51,6 +51,12 @@
       "enum": ["auto", "manual"],
       "type": "string"
     },
+    "breaking_versions": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
     "codenotary": {
       "type": "string",
       "format": "email"


### PR DESCRIPTION
Extension of the add-on config check with the recently added `breaking_versions` option. Available since supervisor version [2024.01.1](https://github.com/home-assistant/supervisor/releases/tag/2024.01.1).

https://github.com/home-assistant/supervisor/pull/4832
https://github.com/home-assistant/developers.home-assistant/pull/2056