### PR TITLE
Add host_uts support

### DIFF
--- a/src/config.schema.json
+++ b/src/config.schema.json
@@ -129,6 +129,10 @@
       "default": false,
       "type": "boolean"
     },
+    "host_uts": {
+      "default": false,
+      "type": "boolean"
+    },
     "image": {
       "type": "string"
     },


### PR DESCRIPTION
`host_uts`property is not defined in config.schema.json and the linter fails if it is added to a configuration:

```
Error: Additional properties are not allowed ('host_uts' was unexpected)
```